### PR TITLE
feat: configurable AI provider and model selection (EDU-5)

### DIFF
--- a/cmd/enrich.go
+++ b/cmd/enrich.go
@@ -14,10 +14,12 @@ import (
 )
 
 var (
-	enrichFrom   string
-	enrichTo     string
-	enrichPeriod string
-	enrichAll    bool
+	enrichFrom     string
+	enrichTo       string
+	enrichPeriod   string
+	enrichAll      bool
+	enrichProvider string
+	enrichModel    string
 )
 
 var enrichCmd = &cobra.Command{
@@ -31,6 +33,8 @@ func init() {
 	enrichCmd.Flags().StringVar(&enrichTo, "to", "", "End date (YYYY-MM-DD)")
 	enrichCmd.Flags().StringVar(&enrichPeriod, "period", "", "Period shorthand (e.g. Q1-2025)")
 	enrichCmd.Flags().BoolVar(&enrichAll, "all", false, "Re-enrich already enriched entries")
+	enrichCmd.Flags().StringVar(&enrichProvider, "provider", "", "AI provider (anthropic, openai)")
+	enrichCmd.Flags().StringVar(&enrichModel, "model", "", "AI model override")
 }
 
 func runEnrich(cmd *cobra.Command, args []string) error {
@@ -39,10 +43,6 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
-	}
-
-	if cfg.AnthropicAPIKey == "" {
-		return fmt.Errorf("anthropic_api_key not configured — run `brag init`")
 	}
 
 	if cfg.Storage.GithubToken == "" || cfg.Storage.Repo == "" {
@@ -86,7 +86,11 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("listing entries: %w", err)
 	}
 
-	enc := enricher.New(cfg.AnthropicAPIKey)
+	provider, model := cfg.ResolveAIProvider(enrichProvider, enrichModel)
+	enc, err := enricher.New(provider, model, cfg.AnthropicAPIKey, cfg.OpenAIAPIKey)
+	if err != nil {
+		return err
+	}
 	var count int
 
 	for _, e := range entries {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,9 +48,15 @@ func runInit(cmd *cobra.Command, args []string) error {
 		cfg.Jira.APIToken = prompt(reader, "Jira API token", cfg.Jira.APIToken)
 	}
 
-	// Anthropic
+	// AI configuration
 	fmt.Println()
+	fmt.Println("--- AI configuration ---")
 	cfg.AnthropicAPIKey = prompt(reader, "Anthropic API key", cfg.AnthropicAPIKey)
+	cfg.AIProvider = promptChoice(reader, "AI provider", []string{config.ProviderAnthropic, config.ProviderOpenAI}, cfg.AIProvider, config.ProviderAnthropic)
+	cfg.AIModel = prompt(reader, "AI model (leave blank for default)", cfg.AIModel)
+	if cfg.AIProvider == config.ProviderOpenAI {
+		cfg.OpenAIAPIKey = prompt(reader, "OpenAI API key", cfg.OpenAIAPIKey)
+	}
 
 	// Sync defaults
 	fmt.Println()
@@ -110,6 +116,26 @@ func prompt(reader *bufio.Reader, label, current string) string {
 		return current
 	}
 	return line
+}
+
+func promptChoice(reader *bufio.Reader, label string, choices []string, current, defaultVal string) string {
+	effective := current
+	if effective == "" {
+		effective = defaultVal
+	}
+	fmt.Printf("%s %v [%s]: ", label, choices, effective)
+	line, _ := reader.ReadString('\n')
+	line = strings.TrimRight(line, "\r\n")
+	if line == "" {
+		return effective
+	}
+	for _, c := range choices {
+		if line == c {
+			return line
+		}
+	}
+	fmt.Printf("Invalid choice %q, keeping %q\n", line, effective)
+	return effective
 }
 
 func maskSecret(s string) string {

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -15,10 +15,12 @@ import (
 )
 
 var (
-	reportFrom   string
-	reportTo     string
-	reportPeriod string
-	reportOKR    string
+	reportFrom     string
+	reportTo       string
+	reportPeriod   string
+	reportOKR      string
+	reportProvider string
+	reportModel    string
 )
 
 var reportCmd = &cobra.Command{
@@ -32,6 +34,8 @@ func init() {
 	reportCmd.Flags().StringVar(&reportTo, "to", "", "End date (YYYY-MM-DD)")
 	reportCmd.Flags().StringVar(&reportPeriod, "period", "", "Period shorthand (e.g. Q1-2025)")
 	reportCmd.Flags().StringVar(&reportOKR, "okr", "", "Filter by OKR ID")
+	reportCmd.Flags().StringVar(&reportProvider, "provider", "", "AI provider (anthropic, openai)")
+	reportCmd.Flags().StringVar(&reportModel, "model", "", "AI model override")
 }
 
 func runReport(cmd *cobra.Command, args []string) error {
@@ -90,10 +94,15 @@ func runReport(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Found %d entries. Generating narrative...\n", len(entries))
 
-	var narrative string
-	if cfg.AnthropicAPIKey != "" {
-		enc := enricher.New(cfg.AnthropicAPIKey)
+	provider, model := cfg.ResolveAIProvider(reportProvider, reportModel)
+	enc, encErr := enricher.New(provider, model, cfg.AnthropicAPIKey, cfg.OpenAIAPIKey)
+	if encErr != nil {
+		fmt.Printf("Warning: AI not configured (%v). Generating without AI narrative.\n", encErr)
+		enc = nil
+	}
 
+	var narrative string
+	if enc != nil {
 		// Enrich any entries that haven't been enriched yet
 		for _, e := range entries {
 			if e.Enriched != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	ProviderAnthropic = "anthropic"
+	ProviderOpenAI    = "openai"
+)
+
 type StarTrailConfig struct {
 	FilePath    string `yaml:"file_path,omitempty"`
 	CurrentRole string `yaml:"current_role,omitempty"`
@@ -57,12 +62,30 @@ type SyncConfig struct {
 
 type Config struct {
 	AnthropicAPIKey string           `yaml:"anthropic_api_key"`
+	OpenAIAPIKey    string           `yaml:"openai_api_key,omitempty"`
+	AIProvider      string           `yaml:"ai_provider,omitempty"`
+	AIModel         string           `yaml:"ai_model,omitempty"`
 	Storage         StorageConfig    `yaml:"storage"`
 	GithubSync      GithubSyncConfig `yaml:"github_sync"`
 	Jira            JiraConfig       `yaml:"jira"`
 	Sync            SyncConfig       `yaml:"sync"`
 	OKRs            []OKR            `yaml:"okrs"`
 	StarTrail       StarTrailConfig  `yaml:"star_trail,omitempty"`
+}
+
+func (c *Config) ResolveAIProvider(providerFlag, modelFlag string) (provider, model string) {
+	provider = providerFlag
+	if provider == "" {
+		provider = c.AIProvider
+	}
+	if provider == "" {
+		provider = ProviderAnthropic
+	}
+	model = modelFlag
+	if model == "" {
+		model = c.AIModel
+	}
+	return provider, model
 }
 
 func ConfigDir() string {

--- a/internal/enricher/anthropic.go
+++ b/internal/enricher/anthropic.go
@@ -1,0 +1,176 @@
+package enricher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/eduardohitek/brag/internal/config"
+)
+
+const anthropicAPIURL = "https://api.anthropic.com/v1/messages"
+const DefaultAnthropicModel = "claude-sonnet-4-20250514"
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	System    string             `json:"system"`
+	Messages  []anthropicMessage `json:"messages"`
+}
+
+type anthropicResponse struct {
+	Content []struct {
+		Text string `json:"text"`
+	} `json:"content"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// AnthropicProvider implements Provider using the Anthropic Messages API.
+type AnthropicProvider struct {
+	apiKey string
+	model  string
+}
+
+func newAnthropicProvider(apiKey, model string) *AnthropicProvider {
+	if model == "" {
+		model = DefaultAnthropicModel
+	}
+	return &AnthropicProvider{apiKey: apiKey, model: model}
+}
+
+func (p *AnthropicProvider) Enrich(ctx context.Context, raw string, okrs []config.OKR, startrail *config.StarTrailConfig) (*EnrichedResult, error) {
+	systemPrompt := buildEnrichSystemPrompt(startrail)
+
+	okrJSON, _ := json.Marshal(okrs)
+	userMsg := fmt.Sprintf("Nota bruta: %s\n\nOKRs ativos: %s", raw, string(okrJSON))
+
+	reqBody := anthropicRequest{
+		Model:     p.model,
+		MaxTokens: 512,
+		System:    systemPrompt,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: userMsg},
+		},
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicAPIURL, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling Anthropic API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	var apiResp anthropicResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return nil, fmt.Errorf("Anthropic API error: %s", apiResp.Error.Message)
+	}
+
+	if len(apiResp.Content) == 0 {
+		return nil, fmt.Errorf("empty response from Anthropic API")
+	}
+
+	text := strings.TrimSpace(apiResp.Content[0].Text)
+	text = strings.TrimPrefix(text, "```json")
+	text = strings.TrimPrefix(text, "```")
+	text = strings.TrimSuffix(text, "```")
+	text = strings.TrimSpace(text)
+
+	var result EnrichedResult
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		return nil, fmt.Errorf("parsing enriched result JSON: %w\nRaw: %s", err, text)
+	}
+
+	return &result, nil
+}
+
+func (p *AnthropicProvider) SynthesizeReport(ctx context.Context, entries interface{}, startrail *config.StarTrailConfig) (string, error) {
+	systemPrompt := buildReportSystemPrompt(startrail)
+
+	entriesJSON, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling entries: %w", err)
+	}
+
+	reqBody := anthropicRequest{
+		Model:     p.model,
+		MaxTokens: 4096,
+		System:    systemPrompt,
+		Messages: []anthropicMessage{
+			{Role: "user", Content: fmt.Sprintf("Entradas:\n%s", string(entriesJSON))},
+		},
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicAPIURL, bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling Anthropic API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
+	var apiResp anthropicResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return "", fmt.Errorf("Anthropic API error: %s", apiResp.Error.Message)
+	}
+
+	if len(apiResp.Content) == 0 {
+		return "", fmt.Errorf("empty response from Anthropic API")
+	}
+
+	return apiResp.Content[0].Text, nil
+}

--- a/internal/enricher/enricher.go
+++ b/internal/enricher/enricher.go
@@ -1,221 +1,37 @@
 package enricher
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
-	"time"
 
 	"github.com/eduardohitek/brag/internal/config"
 )
 
-const anthropicAPIURL = "https://api.anthropic.com/v1/messages"
-const model = "claude-sonnet-4-20250514"
-
+// EnrichedResult is the structured output returned by all providers.
 type EnrichedResult struct {
-	Enriched    string `json:"enriched"`
+	Enriched    string   `json:"enriched"`
 	Tags        []string `json:"tags"`
-	ImpactScore int    `json:"impact_score"`
-	OKRID       *string `json:"okr_id"`
+	ImpactScore int      `json:"impact_score"`
+	OKRID       *string  `json:"okr_id"`
 }
 
-type Enricher struct {
-	apiKey string
-}
+// Enricher is a backward-compatible alias for AnthropicProvider.
+type Enricher = AnthropicProvider
 
-func New(apiKey string) *Enricher {
-	return &Enricher{apiKey: apiKey}
-}
-
-type anthropicMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-}
-
-type anthropicRequest struct {
-	Model     string             `json:"model"`
-	MaxTokens int                `json:"max_tokens"`
-	System    string             `json:"system"`
-	Messages  []anthropicMessage `json:"messages"`
-}
-
-type anthropicResponse struct {
-	Content []struct {
-		Text string `json:"text"`
-	} `json:"content"`
-	Error *struct {
-		Message string `json:"message"`
-	} `json:"error"`
-}
-
-func (e *Enricher) Enrich(ctx context.Context, raw string, okrs []config.OKR, startrail *config.StarTrailConfig) (*EnrichedResult, error) {
-	systemPrompt := `Você é um coach de carreira técnica. Dado um texto bruto de um engenheiro de software e uma lista de OKRs ativos, retorne um objeto JSON com:
-- "enriched": declaração de conquista no formato STAR (1-2 frases)
-- "tags": array com valores de: confiabilidade, velocidade, liderança, mentoria, entrega, qualidade, impacto
-- "impact_score": inteiro de 1 a 5
-- "okr_id": string ou null — preencha apenas se a nota claramente e com alta confiança corresponder a um dos OKRs fornecidos, caso contrário null
-
-Retorne apenas JSON válido, sem markdown.`
-
-	if startrail.IsConfigured() {
-		content, err := startrail.Content()
-		if err == nil && content != "" {
-			startrailSection := fmt.Sprintf(`
-
-Considere também as competências da trilha de carreira abaixo ao avaliar a atividade:
-- Cargo atual: %s`, startrail.CurrentRole)
-			if startrail.TargetRole != "" {
-				startrailSection += fmt.Sprintf("\n- Cargo alvo: %s", startrail.TargetRole)
-			}
-			startrailSection += fmt.Sprintf(`
-
-Trilha de carreira:
----
-%s
----
-Ao gerar "enriched" e o "impact_score", leve em conta como essa atividade demonstra ou avança as competências esperadas para o cargo atual (e para o cargo alvo, se configurado).`, content)
-			systemPrompt += startrailSection
+// New constructs the appropriate Provider for the given provider name.
+// provider and model may be empty strings; defaults are applied automatically.
+func New(provider, model, anthropicKey, openAIKey string) (Provider, error) {
+	switch provider {
+	case config.ProviderAnthropic, "":
+		if anthropicKey == "" {
+			return nil, fmt.Errorf("anthropic_api_key not configured — run `brag init`")
 		}
-	}
-
-	okrJSON, _ := json.Marshal(okrs)
-	userMsg := fmt.Sprintf("Nota bruta: %s\n\nOKRs ativos: %s", raw, string(okrJSON))
-
-	reqBody := anthropicRequest{
-		Model:     model,
-		MaxTokens: 512,
-		System:    systemPrompt,
-		Messages: []anthropicMessage{
-			{Role: "user", Content: userMsg},
-		},
-	}
-
-	data, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicAPIURL, bytes.NewReader(data))
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", e.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
-
-	client := &http.Client{Timeout: 60 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("calling Anthropic API: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	var apiResp anthropicResponse
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return nil, fmt.Errorf("parsing response: %w", err)
-	}
-
-	if apiResp.Error != nil {
-		return nil, fmt.Errorf("Anthropic API error: %s", apiResp.Error.Message)
-	}
-
-	if len(apiResp.Content) == 0 {
-		return nil, fmt.Errorf("empty response from Anthropic API")
-	}
-
-	text := strings.TrimSpace(apiResp.Content[0].Text)
-	// Strip markdown code fences if present
-	text = strings.TrimPrefix(text, "```json")
-	text = strings.TrimPrefix(text, "```")
-	text = strings.TrimSuffix(text, "```")
-	text = strings.TrimSpace(text)
-
-	var result EnrichedResult
-	if err := json.Unmarshal([]byte(text), &result); err != nil {
-		return nil, fmt.Errorf("parsing enriched result JSON: %w\nRaw: %s", err, text)
-	}
-
-	return &result, nil
-}
-
-func (e *Enricher) SynthesizeReport(ctx context.Context, entries interface{}, startrail *config.StarTrailConfig) (string, error) {
-	systemPrompt := `Você é um coach de carreira técnica ajudando um engenheiro de software a escrever uma autoavaliação de desempenho.
-Com base em uma lista de registros de trabalho enriquecidos, gere um relatório narrativo coeso adequado para uma avaliação de desempenho.
-Estruture o relatório com:
-1. Seções agrupadas por OKR primeiro (uma seção por OKR com suas entradas)
-2. Uma seção "Conquistas Gerais" para entradas sem OKR
-
-Use formatação markdown. Seja específico, impactante e profissional. Foque em resultados e impacto no negócio.`
-
-	if startrail.IsConfigured() {
-		roleNote := fmt.Sprintf("\n\nAo escrever a narrativa, mencione o progresso em competências relevantes para o cargo atual (%s)", startrail.CurrentRole)
-		if startrail.TargetRole != "" {
-			roleNote += fmt.Sprintf(" e para o cargo alvo (%s)", startrail.TargetRole)
+		return newAnthropicProvider(anthropicKey, model), nil
+	case config.ProviderOpenAI:
+		if openAIKey == "" {
+			return nil, fmt.Errorf("openai_api_key not configured — run `brag init`")
 		}
-		roleNote += "."
-		systemPrompt += roleNote
+		return newOpenAIProvider(openAIKey, model), nil
+	default:
+		return nil, fmt.Errorf("unknown ai_provider %q — supported: anthropic, openai", provider)
 	}
-
-	entriesJSON, err := json.MarshalIndent(entries, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshaling entries: %w", err)
-	}
-
-	reqBody := anthropicRequest{
-		Model:     model,
-		MaxTokens: 4096,
-		System:    systemPrompt,
-		Messages: []anthropicMessage{
-			{Role: "user", Content: fmt.Sprintf("Entradas:\n%s", string(entriesJSON))},
-		},
-	}
-
-	data, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", fmt.Errorf("marshaling request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicAPIURL, bytes.NewReader(data))
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", e.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
-
-	client := &http.Client{Timeout: 120 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("calling Anthropic API: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("reading response: %w", err)
-	}
-
-	var apiResp anthropicResponse
-	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return "", fmt.Errorf("parsing response: %w", err)
-	}
-
-	if apiResp.Error != nil {
-		return "", fmt.Errorf("Anthropic API error: %s", apiResp.Error.Message)
-	}
-
-	if len(apiResp.Content) == 0 {
-		return "", fmt.Errorf("empty response from Anthropic API")
-	}
-
-	return apiResp.Content[0].Text, nil
 }

--- a/internal/enricher/openai.go
+++ b/internal/enricher/openai.go
@@ -1,0 +1,175 @@
+package enricher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/eduardohitek/brag/internal/config"
+)
+
+const openAIAPIURL = "https://api.openai.com/v1/chat/completions"
+const DefaultOpenAIModel = "gpt-4o"
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIRequest struct {
+	Model     string          `json:"model"`
+	MaxTokens int             `json:"max_tokens"`
+	Messages  []openAIMessage `json:"messages"`
+}
+
+type openAIChoice struct {
+	Message openAIMessage `json:"message"`
+}
+
+type openAIResponse struct {
+	Choices []openAIChoice `json:"choices"`
+	Error   *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// OpenAIProvider implements Provider using the OpenAI Chat Completions API.
+type OpenAIProvider struct {
+	apiKey string
+	model  string
+}
+
+func newOpenAIProvider(apiKey, model string) *OpenAIProvider {
+	if model == "" {
+		model = DefaultOpenAIModel
+	}
+	return &OpenAIProvider{apiKey: apiKey, model: model}
+}
+
+func (p *OpenAIProvider) Enrich(ctx context.Context, raw string, okrs []config.OKR, startrail *config.StarTrailConfig) (*EnrichedResult, error) {
+	systemPrompt := buildEnrichSystemPrompt(startrail)
+
+	okrJSON, _ := json.Marshal(okrs)
+	userMsg := fmt.Sprintf("Nota bruta: %s\n\nOKRs ativos: %s", raw, string(okrJSON))
+
+	reqBody := openAIRequest{
+		Model:     p.model,
+		MaxTokens: 512,
+		Messages: []openAIMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: userMsg},
+		},
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIAPIURL, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling OpenAI API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	var apiResp openAIResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("parsing response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return nil, fmt.Errorf("OpenAI API error: %s", apiResp.Error.Message)
+	}
+
+	if len(apiResp.Choices) == 0 {
+		return nil, fmt.Errorf("empty response from OpenAI API")
+	}
+
+	text := strings.TrimSpace(apiResp.Choices[0].Message.Content)
+	text = strings.TrimPrefix(text, "```json")
+	text = strings.TrimPrefix(text, "```")
+	text = strings.TrimSuffix(text, "```")
+	text = strings.TrimSpace(text)
+
+	var result EnrichedResult
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
+		return nil, fmt.Errorf("parsing enriched result JSON: %w\nRaw: %s", err, text)
+	}
+
+	return &result, nil
+}
+
+func (p *OpenAIProvider) SynthesizeReport(ctx context.Context, entries interface{}, startrail *config.StarTrailConfig) (string, error) {
+	systemPrompt := buildReportSystemPrompt(startrail)
+
+	entriesJSON, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling entries: %w", err)
+	}
+
+	reqBody := openAIRequest{
+		Model:     p.model,
+		MaxTokens: 4096,
+		Messages: []openAIMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: fmt.Sprintf("Entradas:\n%s", string(entriesJSON))},
+		},
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshaling request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIAPIURL, bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("calling OpenAI API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
+	var apiResp openAIResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return "", fmt.Errorf("OpenAI API error: %s", apiResp.Error.Message)
+	}
+
+	if len(apiResp.Choices) == 0 {
+		return "", fmt.Errorf("empty response from OpenAI API")
+	}
+
+	return apiResp.Choices[0].Message.Content, nil
+}

--- a/internal/enricher/prompts.go
+++ b/internal/enricher/prompts.go
@@ -1,0 +1,61 @@
+package enricher
+
+import (
+	"fmt"
+
+	"github.com/eduardohitek/brag/internal/config"
+)
+
+func buildEnrichSystemPrompt(startrail *config.StarTrailConfig) string {
+	prompt := `Você é um coach de carreira técnica. Dado um texto bruto de um engenheiro de software e uma lista de OKRs ativos, retorne um objeto JSON com:
+- "enriched": declaração de conquista no formato STAR (1-2 frases)
+- "tags": array com valores de: confiabilidade, velocidade, liderança, mentoria, entrega, qualidade, impacto
+- "impact_score": inteiro de 1 a 5
+- "okr_id": string ou null — preencha apenas se a nota claramente e com alta confiança corresponder a um dos OKRs fornecidos, caso contrário null
+
+Retorne apenas JSON válido, sem markdown.`
+
+	if startrail.IsConfigured() {
+		content, err := startrail.Content()
+		if err == nil && content != "" {
+			startrailSection := fmt.Sprintf(`
+
+Considere também as competências da trilha de carreira abaixo ao avaliar a atividade:
+- Cargo atual: %s`, startrail.CurrentRole)
+			if startrail.TargetRole != "" {
+				startrailSection += fmt.Sprintf("\n- Cargo alvo: %s", startrail.TargetRole)
+			}
+			startrailSection += fmt.Sprintf(`
+
+Trilha de carreira:
+---
+%s
+---
+Ao gerar "enriched" e o "impact_score", leve em conta como essa atividade demonstra ou avança as competências esperadas para o cargo atual (e para o cargo alvo, se configurado).`, content)
+			prompt += startrailSection
+		}
+	}
+
+	return prompt
+}
+
+func buildReportSystemPrompt(startrail *config.StarTrailConfig) string {
+	prompt := `Você é um coach de carreira técnica ajudando um engenheiro de software a escrever uma autoavaliação de desempenho.
+Com base em uma lista de registros de trabalho enriquecidos, gere um relatório narrativo coeso adequado para uma avaliação de desempenho.
+Estruture o relatório com:
+1. Seções agrupadas por OKR primeiro (uma seção por OKR com suas entradas)
+2. Uma seção "Conquistas Gerais" para entradas sem OKR
+
+Use formatação markdown. Seja específico, impactante e profissional. Foque em resultados e impacto no negócio.`
+
+	if startrail.IsConfigured() {
+		roleNote := fmt.Sprintf("\n\nAo escrever a narrativa, mencione o progresso em competências relevantes para o cargo atual (%s)", startrail.CurrentRole)
+		if startrail.TargetRole != "" {
+			roleNote += fmt.Sprintf(" e para o cargo alvo (%s)", startrail.TargetRole)
+		}
+		roleNote += "."
+		prompt += roleNote
+	}
+
+	return prompt
+}

--- a/internal/enricher/provider.go
+++ b/internal/enricher/provider.go
@@ -1,0 +1,13 @@
+package enricher
+
+import (
+	"context"
+
+	"github.com/eduardohitek/brag/internal/config"
+)
+
+// Provider is the interface satisfied by all AI backend implementations.
+type Provider interface {
+	Enrich(ctx context.Context, raw string, okrs []config.OKR, startrail *config.StarTrailConfig) (*EnrichedResult, error)
+	SynthesizeReport(ctx context.Context, entries interface{}, startrail *config.StarTrailConfig) (string, error)
+}


### PR DESCRIPTION
## Summary

- Introduces a `Provider` interface so multiple AI backends can satisfy the same contract
- Extracts Anthropic into `anthropic.go` and adds an OpenAI implementation in `openai.go` (plain HTTP, no new module dependencies)
- Shared prompt builders moved to `prompts.go` so both providers produce identical prompts
- `config.go` gains `openai_api_key`, `ai_provider`, `ai_model` fields and a `ResolveAIProvider()` helper (existing `anthropic_api_key` YAML tag unchanged — fully backward compatible)
- `brag enrich` and `brag report` accept new `--provider` and `--model` flags; `brag init` wizard prompts for the new fields

## Test plan

- [ ] `go build ./...` compiles with zero errors
- [ ] `brag enrich` with only `anthropic_api_key` in config → enriches as before (default behaviour unchanged)
- [ ] `brag enrich --provider openai --model gpt-4o-mini` with `openai_api_key` set → uses OpenAI
- [ ] `brag enrich --provider openai` with no `openai_api_key` → clear error: *openai_api_key not configured — run `brag init`*
- [ ] `brag enrich --provider gemini` → clear error: *unknown ai_provider "gemini" — supported: anthropic, openai*
- [ ] `brag init` → prompts include AI provider choice, model, and conditionally OpenAI key
- [ ] `brag report` with no AI key configured → plain report generated with warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)