### PR TITLE
feat: add brag sync-cache command (EDU-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ brag sync           # usa default_days do config
 brag sync --days 14
 ```
 
+### Sincronizar cache local com o repositório GitHub
+
+```sh
+brag sync-cache
+```
+
+Lê todos os arquivos de `~/.brag/cache/` e envia para o repositório GitHub as entradas que ainda não estão presentes. Útil quando o armazenamento no GitHub foi configurado após a criação de entradas locais.
+
 ### Listar entradas
 
 ```sh

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,4 +35,5 @@ func init() {
 	rootCmd.AddCommand(okrCmd)
 	rootCmd.AddCommand(startrailCmd)
 	rootCmd.AddCommand(enrichCmd)
+	rootCmd.AddCommand(syncCacheCmd)
 }

--- a/cmd/sync_cache.go
+++ b/cmd/sync_cache.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/eduardohitek/brag/internal/config"
+	"github.com/eduardohitek/brag/internal/store"
+)
+
+var syncCacheCmd = &cobra.Command{
+	Use:   "sync-cache",
+	Short: "Push local cache entries to GitHub storage",
+	Long:  `Reads all entries from the local cache (~/.brag/cache/) and uploads any that are not already present in the configured GitHub storage repository.`,
+	RunE:  runSyncCache,
+}
+
+func runSyncCache(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	if cfg.Storage.GithubToken == "" || cfg.Storage.Repo == "" {
+		return fmt.Errorf("GitHub storage not configured — run `brag init`")
+	}
+
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	if err != nil {
+		return fmt.Errorf("creating store: %w", err)
+	}
+
+	// Fetch all existing GitHub entries once and build lookup maps
+	fmt.Println("Fetching existing entries from GitHub...")
+	existing, err := s.ListEntries(ctx, store.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing GitHub entries: %w", err)
+	}
+	uploadedIDs := make(map[string]bool, len(existing))
+	uploadedURLs := make(map[string]bool)
+	for _, e := range existing {
+		uploadedIDs[e.ID] = true
+		if e.SourceURL != "" {
+			uploadedURLs[e.SourceURL] = true
+		}
+	}
+
+	// Read cache files
+	cacheDir := config.CacheDir()
+	dirEntries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("Local cache is empty — nothing to upload.")
+			return nil
+		}
+		return fmt.Errorf("reading cache dir: %w", err)
+	}
+
+	var uploaded, skipped, failed int
+	for _, de := range dirEntries {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+
+		path := filepath.Join(cacheDir, de.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: reading %s: %v\n", de.Name(), err)
+			failed++
+			continue
+		}
+
+		var e store.Entry
+		if err := json.Unmarshal(data, &e); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: parsing %s: %v\n", de.Name(), err)
+			failed++
+			continue
+		}
+
+		// Deduplication: by SourceURL for synced entries, by ID for manual entries
+		if e.SourceURL != "" {
+			if uploadedURLs[e.SourceURL] {
+				skipped++
+				continue
+			}
+		} else {
+			if uploadedIDs[e.ID] {
+				skipped++
+				continue
+			}
+		}
+
+		if err := s.SaveEntry(ctx, &e); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: uploading %s: %v\n", e.ID, err)
+			failed++
+			continue
+		}
+
+		uploadedIDs[e.ID] = true
+		if e.SourceURL != "" {
+			uploadedURLs[e.SourceURL] = true
+		}
+		fmt.Printf("  + [%s] %s\n", e.Source, e.Raw)
+		uploaded++
+	}
+
+	fmt.Printf("\nSync-cache complete:\n")
+	fmt.Printf("  Uploaded: %d\n", uploaded)
+	fmt.Printf("  Skipped (already in GitHub): %d\n", skipped)
+	if failed > 0 {
+		fmt.Printf("  Failed: %d\n", failed)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `brag sync-cache` subcommand that reads all JSON entries from `~/.brag/cache/` and uploads to the configured GitHub storage repo any entries not already present
- Deduplicates by `SourceURL` for github/jira entries and by `ID` for manual entries
- Fetches all existing GitHub entries once up front (single API call) to build in-memory lookup maps — avoids N API calls per entry
- Updates README (pt-BR) with documentation for the new command

Closes #3

## Test plan

- [ ] Run `brag add "test"` without GitHub storage configured → entry appears in `~/.brag/cache/`
- [ ] Configure `storage.github_token` and `storage.repo` in `~/.brag/config.yaml`
- [ ] Run `brag sync-cache` → entry uploaded, summary shows `Uploaded: 1, Skipped: 0`
- [ ] Run `brag sync-cache` again → summary shows `Uploaded: 0, Skipped: 1` (dedup works)
- [ ] Run `brag list` → entry visible
- [ ] Run without GitHub storage configured → returns clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)