### PR TITLE
feat: Linear Sync — import completed issues as entries (EDU-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Uma ferramenta de linha de comando para engenheiros de software registrarem conq
 - **Entradas manuais** via `brag add` com enriquecimento por IA (formato STAR, tags, pontuação de impacto)
 - **Sincronização com GitHub** — PRs mergeados e issues fechadas por você
 - **Sincronização com Jira** — tickets movidos para Done
+- **Sincronização com Linear** — issues concluídas e atribuídas a você
 - **Rastreamento de OKRs** — associe entradas a OKRs; a IA infere com alta confiança
 - **StarTrail (trilha de carreira)** — contexto opcional de trilha de carreira para que o enriquecimento por IA reflita as competências do seu cargo
 - **Relatórios de desempenho** — narrativa sintetizada por IA, agrupada por OKR, exportável em Markdown e PDF
@@ -79,6 +80,9 @@ jira:
   base_url: "https://suaempresa.atlassian.net"
   email: "voce@empresa.com"
   api_token: "..."
+linear:
+  api_key: "lin_api_..."
+  team_id: "uuid-do-time"     # opcional — filtra por um time específico
 sync:
   default_days: 30
 okrs:
@@ -100,12 +104,14 @@ brag add "Corrigi um bug crítico de autenticação que afetava 20% dos usuário
 brag add "Liderança na migração para Kubernetes" --project minha-plataforma --okr OKR-2025-Q1-01
 ```
 
-### Sincronizar GitHub + Jira
+### Sincronizar GitHub, Jira e Linear
 
 ```sh
 brag sync           # usa default_days do config
 brag sync --days 14
 ```
+
+Cada fonte é sincronizada apenas se estiver configurada no `~/.brag/config.yaml`. Entradas já importadas são ignoradas (deduplicação por URL).
 
 ### Sincronizar cache local com o repositório GitHub
 
@@ -255,3 +261,9 @@ O enriquecimento realiza:
 1. Acesse [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 2. Crie um novo token de API
 3. Adicione ao config como `jira.api_token`
+
+### Linear API key
+1. Acesse **linear.app → Settings → API → Personal API keys**
+2. Crie uma nova chave pessoal
+3. Adicione ao config como `linear.api_key`
+4. (Opcional) Para filtrar por um time específico, adicione o UUID do time em `linear.team_id`

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/eduardohitek/brag/internal/config"
 	ghsync "github.com/eduardohitek/brag/internal/github"
 	"github.com/eduardohitek/brag/internal/jira"
+	"github.com/eduardohitek/brag/internal/linear"
 	"github.com/eduardohitek/brag/internal/store"
 )
 
@@ -50,7 +51,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating store: %w", err)
 	}
 
-	var githubCount, jiraCount int
+	var githubCount, jiraCount, linearCount int
 
 	// Sync GitHub
 	if cfg.GithubSync.Token != "" && cfg.GithubSync.Username != "" {
@@ -107,9 +108,30 @@ func runSync(cmd *cobra.Command, args []string) error {
 		fmt.Println("Jira sync skipped (not configured).")
 	}
 
+	// Sync Linear
+	if cfg.Linear.IsConfigured() {
+		fmt.Printf("Syncing Linear (last %d days)...\n", days)
+		linearClient := linear.New(cfg.Linear.APIKey, cfg.Linear.TeamID)
+		issues, err := linearClient.FetchRecentCompletedIssues(ctx, days)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Linear sync failed: %v\n", err)
+		} else {
+			for _, e := range issues {
+				n, err := processAndSaveEntry(ctx, e, s)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to save Linear entry: %v\n", err)
+				}
+				linearCount += n
+			}
+		}
+	} else {
+		fmt.Println("Linear sync skipped (not configured).")
+	}
+
 	fmt.Printf("\nSync complete:\n")
 	fmt.Printf("  GitHub: %d new entries\n", githubCount)
 	fmt.Printf("  Jira:   %d new entries\n", jiraCount)
+	fmt.Printf("  Linear: %d new entries\n", linearCount)
 
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,15 @@ type JiraConfig struct {
 	APIToken string `yaml:"api_token"`
 }
 
+type LinearConfig struct {
+	APIKey string `yaml:"api_key"`
+	TeamID string `yaml:"team_id,omitempty"`
+}
+
+func (c *LinearConfig) IsConfigured() bool {
+	return c.APIKey != ""
+}
+
 type SyncConfig struct {
 	DefaultDays int `yaml:"default_days"`
 }
@@ -68,6 +77,7 @@ type Config struct {
 	Storage         StorageConfig    `yaml:"storage"`
 	GithubSync      GithubSyncConfig `yaml:"github_sync"`
 	Jira            JiraConfig       `yaml:"jira"`
+	Linear          LinearConfig     `yaml:"linear"`
 	Sync            SyncConfig       `yaml:"sync"`
 	OKRs            []OKR            `yaml:"okrs"`
 	StarTrail       StarTrailConfig  `yaml:"star_trail,omitempty"`

--- a/internal/linear/sync.go
+++ b/internal/linear/sync.go
@@ -1,0 +1,175 @@
+package linear
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/eduardohitek/brag/internal/store"
+)
+
+const apiURL = "https://api.linear.app/graphql"
+
+type Client struct {
+	apiKey string
+	teamID string
+	http   *http.Client
+}
+
+func New(apiKey, teamID string) *Client {
+	return &Client{
+		apiKey: apiKey,
+		teamID: teamID,
+		http:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+type graphqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+type linearIssue struct {
+	ID          string    `json:"id"`
+	Identifier  string    `json:"identifier"`
+	Title       string    `json:"title"`
+	URL         string    `json:"url"`
+	CompletedAt time.Time `json:"completedAt"`
+}
+
+type pageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type graphqlResponse struct {
+	Data struct {
+		Issues struct {
+			Nodes    []linearIssue `json:"nodes"`
+			PageInfo pageInfo      `json:"pageInfo"`
+		} `json:"issues"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+var queryWithoutTeam = `
+query CompletedIssues($after: DateTime, $cursor: String) {
+  issues(
+    first: 100
+    after: $cursor
+    filter: {
+      assignee: { isMe: { eq: true } }
+      state: { type: { eq: "completed" } }
+      completedAt: { gt: $after }
+    }
+  ) {
+    nodes { id identifier title url completedAt }
+    pageInfo { hasNextPage endCursor }
+  }
+}`
+
+var queryWithTeam = `
+query CompletedIssues($after: DateTime, $cursor: String, $teamId: ID!) {
+  issues(
+    first: 100
+    after: $cursor
+    filter: {
+      assignee: { isMe: { eq: true } }
+      state: { type: { eq: "completed" } }
+      completedAt: { gt: $after }
+      team: { id: { eq: $teamId } }
+    }
+  ) {
+    nodes { id identifier title url completedAt }
+    pageInfo { hasNextPage endCursor }
+  }
+}`
+
+func (c *Client) FetchRecentCompletedIssues(ctx context.Context, days int) ([]*store.Entry, error) {
+	after := time.Now().AddDate(0, 0, -days).UTC().Format(time.RFC3339)
+
+	query := queryWithoutTeam
+	if c.teamID != "" {
+		query = queryWithTeam
+	}
+
+	var entries []*store.Entry
+	var cursor *string
+
+	for {
+		vars := map[string]any{
+			"after": after,
+		}
+		if cursor != nil {
+			vars["cursor"] = *cursor
+		}
+		if c.teamID != "" {
+			vars["teamId"] = c.teamID
+		}
+
+		reqBody := graphqlRequest{
+			Query:     query,
+			Variables: vars,
+		}
+
+		body, err := json.Marshal(reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling Linear request: %w", err)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("creating Linear request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("calling Linear API: %w", err)
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading Linear response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Linear API returned %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		var gqlResp graphqlResponse
+		if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+			return nil, fmt.Errorf("parsing Linear response: %w", err)
+		}
+
+		if len(gqlResp.Errors) > 0 {
+			return nil, fmt.Errorf("Linear API error: %s", gqlResp.Errors[0].Message)
+		}
+
+		for _, issue := range gqlResp.Data.Issues.Nodes {
+			entries = append(entries, &store.Entry{
+				ID:        issue.Identifier,
+				Date:      issue.CompletedAt,
+				Raw:       issue.Title,
+				Source:    "linear",
+				SourceURL: issue.URL,
+			})
+		}
+
+		if !gqlResp.Data.Issues.PageInfo.HasNextPage {
+			break
+		}
+		end := gqlResp.Data.Issues.PageInfo.EndCursor
+		cursor = &end
+	}
+
+	return entries, nil
+}

--- a/internal/store/entry.go
+++ b/internal/store/entry.go
@@ -13,7 +13,7 @@ type Entry struct {
 	Raw           string    `json:"raw"`
 	Enriched      string    `json:"enriched"`
 	Tags          []string  `json:"tags"`
-	Source        string    `json:"source"` // manual | github | jira
+	Source        string    `json:"source"` // manual | github | jira | linear
 	SourceURL     string    `json:"source_url,omitempty"`
 	GithubProject string    `json:"github_project,omitempty"`
 	OKR           *OKRRef   `json:"okr,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `internal/linear` package with a GraphQL client that fetches completed issues assigned to the authenticated user, with full cursor-based pagination
- Adds `LinearConfig` struct to `internal/config` (yaml key: `linear`, fields: `api_key`, optional `team_id`)
- Updates `Entry.Source` comment to include `linear` as a valid value
- Integrates Linear sync into `brag sync` command, following the same pattern as GitHub and Jira (skip silently if not configured, deduplicate via `SourceURL`)

## Config

```yaml
linear:
  api_key: "lin_api_xxxx"
  team_id: "optional-team-uuid"  # filter to a specific team if set
```

## Test plan

- [ ] `go build -o brag .` compiles without errors
- [ ] `go vet ./...` passes with no warnings
- [ ] `brag sync` with no `linear` block in config prints `Linear sync skipped (not configured.)`
- [ ] `brag sync` with a valid `api_key` prints `Syncing Linear (last N days)...` and imports entries
- [ ] Running `brag sync` twice does not create duplicate entries (deduplication via `SourceURL`)
- [ ] Invalid `api_key` prints `Warning: Linear sync failed: Linear API returned 401: ...` and exits 0

Closes EDU-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)