### PR TITLE
feat: add bilingual landing page with GitHub Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./docs"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -1,0 +1,592 @@
+/* =============================
+   CSS Variables — Dark (default)
+   ============================= */
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --surface-hover: #1c2128;
+  --border: #30363d;
+  --text: #c9d1d9;
+  --text-muted: #8b949e;
+  --accent: #39d353;
+  --accent-dim: #2ea043;
+  --accent-glow: rgba(57, 211, 83, 0.15);
+  --code-bg: #010409;
+  --shadow: rgba(0, 0, 0, 0.4);
+  --tab-active-bg: #21262d;
+  --transition: 0.25s ease;
+}
+
+[data-theme="light"] {
+  --bg: #ffffff;
+  --surface: #f6f8fa;
+  --surface-hover: #eaeef2;
+  --border: #d0d7de;
+  --text: #1f2328;
+  --text-muted: #656d76;
+  --accent: #1a7f37;
+  --accent-dim: #116329;
+  --accent-glow: rgba(26, 127, 55, 0.12);
+  --code-bg: #f6f8fa;
+  --shadow: rgba(0, 0, 0, 0.08);
+  --tab-active-bg: #ffffff;
+}
+
+/* =============================
+   Reset & Base
+   ============================= */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  transition: background var(--transition), color var(--transition);
+  min-height: 100vh;
+}
+
+a { color: var(--accent); text-decoration: none; transition: opacity 0.2s; }
+a:hover { opacity: 0.8; }
+
+/* =============================
+   Header / Nav
+   ============================= */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+  backdrop-filter: blur(8px);
+  transition: background var(--transition), border-color var(--transition);
+}
+
+.site-header .logo {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+}
+
+.logo .prompt { color: var(--text-muted); margin-right: 4px; }
+
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-icon {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition);
+  font-family: inherit;
+}
+
+.btn-icon:hover { background: var(--surface-hover); }
+
+/* =============================
+   Hero
+   ============================= */
+.hero {
+  padding: 6rem 1.5rem 5rem;
+  text-align: center;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.hero-badge {
+  display: inline-block;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.78rem;
+  color: var(--accent);
+  background: var(--accent-glow);
+  border: 1px solid var(--accent-dim);
+  border-radius: 20px;
+  padding: 0.25rem 0.9rem;
+  margin-bottom: 1.5rem;
+  letter-spacing: 0.04em;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  margin-bottom: 1.2rem;
+}
+
+.hero h1 .accent { color: var(--accent); }
+
+.hero-subtitle {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  max-width: 600px;
+  margin: 0 auto 2.5rem;
+}
+
+.hero-ctas {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #0d1117;
+  font-weight: 700;
+  border: none;
+  border-radius: 8px;
+  padding: 0.7rem 1.4rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.15s;
+  font-family: inherit;
+}
+
+.btn-primary:hover { opacity: 0.9; transform: translateY(-1px); }
+
+.btn-secondary {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.7rem 1.4rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), transform 0.15s;
+  font-family: inherit;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.btn-secondary:hover { background: var(--surface); transform: translateY(-1px); }
+
+.hero-install {
+  margin-top: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.install-snippet {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.6rem 1.2rem;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.9rem;
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.install-snippet .prompt-char { color: var(--text-muted); }
+
+.copy-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 1rem;
+  padding: 0;
+  transition: color 0.2s;
+  display: flex;
+  align-items: center;
+}
+
+.copy-btn:hover { color: var(--accent); }
+.copy-btn.copied { color: var(--accent); }
+
+/* cursor blink */
+.cursor {
+  display: inline-block;
+  width: 10px;
+  height: 1em;
+  background: var(--accent);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* =============================
+   Sections
+   ============================= */
+section { padding: 5rem 1.5rem; }
+section:nth-child(even) { background: var(--surface); transition: background var(--transition); }
+
+.section-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.section-title {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 700;
+  margin-bottom: 0.6rem;
+  letter-spacing: -0.01em;
+}
+
+.section-subtitle {
+  color: var(--text-muted);
+  font-size: 1rem;
+  margin-bottom: 3rem;
+}
+
+/* =============================
+   Features Grid
+   ============================= */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.2rem;
+}
+
+.feature-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  transition: background var(--transition), border-color var(--transition), transform 0.2s, box-shadow 0.2s;
+}
+
+.feature-card:hover {
+  border-color: var(--accent-dim);
+  box-shadow: 0 0 0 1px var(--accent-dim), 0 4px 20px var(--shadow);
+  transform: translateY(-2px);
+}
+
+[data-theme="light"] .feature-card { background: var(--surface); }
+
+.feature-icon {
+  font-size: 1.8rem;
+  margin-bottom: 0.8rem;
+  display: block;
+}
+
+.feature-title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+  color: var(--text);
+}
+
+.feature-desc {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* =============================
+   How it works
+   ============================= */
+.steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 2rem;
+  position: relative;
+}
+
+.step {
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border: 2px solid var(--accent);
+  border-radius: 50%;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.step-title {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.step-desc { font-size: 0.9rem; color: var(--text-muted); }
+
+.step-code {
+  display: inline-block;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.85rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.3rem 0.7rem;
+  color: var(--accent);
+  margin-top: 0.6rem;
+}
+
+/* =============================
+   Installation Tabs
+   ============================= */
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.6rem 1.2rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s;
+  font-family: inherit;
+  margin-bottom: -1px;
+}
+
+.tab-btn:hover { color: var(--text); }
+.tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+.tab-panel { display: none; }
+.tab-panel.active { display: block; }
+
+.code-block {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.2rem 1.5rem;
+  position: relative;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+.code-block pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.88rem;
+  color: var(--text);
+  white-space: pre-wrap;
+  line-height: 1.7;
+}
+
+.code-block .comment { color: var(--text-muted); }
+.code-block .cmd { color: var(--accent); }
+
+.code-copy-btn {
+  position: absolute;
+  top: 0.8rem;
+  right: 0.8rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background var(--transition), color 0.2s;
+  font-family: inherit;
+}
+
+.code-copy-btn:hover { color: var(--accent); background: var(--surface-hover); }
+.code-copy-btn.copied { color: var(--accent); }
+
+/* =============================
+   About Author
+   ============================= */
+.about-card {
+  display: flex;
+  gap: 2.5rem;
+  align-items: flex-start;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2.5rem;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+[data-theme="light"] .about-card { background: var(--bg); }
+
+.about-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 3px solid var(--accent);
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.about-info h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+}
+
+.about-role {
+  color: var(--accent);
+  font-size: 0.9rem;
+  margin-bottom: 0.8rem;
+  font-family: "Courier New", Courier, monospace;
+}
+
+.about-bio {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin-bottom: 1.2rem;
+  line-height: 1.6;
+}
+
+.social-links {
+  display: flex;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.social-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  color: var(--text);
+  transition: background var(--transition), border-color var(--transition), color 0.2s;
+}
+
+.social-link:hover { border-color: var(--accent); color: var(--accent); opacity: 1; }
+
+[data-theme="light"] .social-link { background: var(--surface); }
+
+/* =============================
+   Footer
+   ============================= */
+footer {
+  border-top: 1px solid var(--border);
+  padding: 2rem 1.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  transition: border-color var(--transition);
+}
+
+footer a { color: var(--text-muted); }
+footer a:hover { color: var(--accent); opacity: 1; }
+
+.footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* =============================
+   Responsive
+   ============================= */
+@media (max-width: 640px) {
+  .about-card { flex-direction: column; align-items: center; text-align: center; }
+  .social-links { justify-content: center; }
+  .hero { padding: 4rem 1rem 3rem; }
+  section { padding: 3.5rem 1rem; }
+  .hero-ctas { flex-direction: column; align-items: center; }
+}
+
+/* =============================
+   Demo Terminal
+   ============================= */
+.demo-terminal {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  max-width: 700px;
+  margin: 0 auto;
+  box-shadow: 0 8px 32px var(--shadow);
+}
+
+.terminal-bar {
+  background: #21262d;
+  padding: 0.6rem 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.terminal-dot.red    { background: #ff5f57; }
+.terminal-dot.yellow { background: #febc2e; }
+.terminal-dot.green  { background: #28c840; }
+
+.terminal-title {
+  font-size: 0.75rem;
+  color: #8b949e;
+  margin-left: auto;
+  font-family: "Courier New", Courier, monospace;
+}
+
+.terminal-body {
+  background: #010409;
+  padding: 1.4rem 1.6rem;
+}
+
+.terminal-body pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 0.88rem;
+  line-height: 1.8;
+  color: #c9d1d9;
+  white-space: pre-wrap;
+}
+
+.terminal-body .t-prompt  { color: #39d353; }
+.terminal-body .t-question { color: #79c0ff; }
+.terminal-body .t-answer  { color: #c9d1d9; }
+.terminal-body .t-success { color: #39d353; }
+.terminal-body .t-muted   { color: #8b949e; }
+
+/* =============================
+   Scrollbar
+   ============================= */
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>brag — Track every win. Own your career.</title>
+  <meta name="description" content="A CLI tool for software engineers to log accomplishments, sync GitHub PRs, Jira tickets, and Linear issues, enrich with AI (STAR format), and generate performance review reports." />
+  <meta property="og:title" content="brag — Track every win. Own your career." />
+  <meta property="og:description" content="CLI tool to log accomplishments, sync GitHub/Jira/Linear, enrich with AI (STAR), and generate performance reports." />
+  <meta property="og:image" content="https://avatars.githubusercontent.com/u/88193?v=4" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:creator" content="@eduardohitek" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⭐</text></svg>" />
+  <link rel="stylesheet" href="css/styles.css" />
+</head>
+<body>
+
+  <!-- ══ HEADER ══════════════════════════════════════════ -->
+  <header class="site-header">
+    <a href="#" class="logo">
+      <span class="prompt">$</span> brag
+    </a>
+    <div class="header-controls">
+      <button id="themeToggle" class="btn-icon" aria-label="Toggle theme">🌙</button>
+      <button id="langToggle" class="btn-icon" aria-label="Toggle language" data-i18n="nav.lang">PT</button>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ══ HERO ═════════════════════════════════════════ -->
+    <section class="hero" style="max-width:100%;padding-top:6rem;padding-bottom:5rem;">
+      <div class="section-inner" style="text-align:center;">
+        <span class="hero-badge" data-i18n="hero.badge">v0.8.0 — Open Source CLI</span>
+
+        <h1>
+          <span data-i18n="hero.h1.line1">Track every win.</span><br />
+          <span class="accent" data-i18n="hero.h1.line2">Own your career.</span><span class="cursor"></span>
+        </h1>
+
+        <p class="hero-subtitle" data-i18n="hero.subtitle">
+          A CLI tool for software engineers to log accomplishments, sync GitHub PRs, Jira tickets, and Linear issues, enrich them with AI using the STAR format, and generate structured performance review reports.
+        </p>
+
+        <div class="hero-ctas">
+          <a href="https://github.com/eduardohitek/brag-cli" target="_blank" rel="noopener" class="btn-secondary">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+            <span data-i18n="hero.cta.github">View on GitHub</span>
+          </a>
+          <a href="https://github.com/eduardohitek/brag-cli/releases/latest" target="_blank" rel="noopener" class="btn-primary" data-i18n="install.tab.download">Download</a>
+        </div>
+
+        <div class="hero-install">
+          <span class="hero-install-label" style="color:var(--text-muted);font-size:0.85rem;" data-i18n="hero.install.label">Quick install:</span>
+          <div class="install-snippet">
+            <span class="prompt-char">$</span>
+            <span>brew install eduardohitek/tap/brag</span>
+            <button class="copy-btn" data-copy="brew install eduardohitek/tap/brag" aria-label="Copy install command" data-i18n="hero.install.copy">Copy</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══ FEATURES ══════════════════════════════════════ -->
+    <section id="features">
+      <div class="section-inner">
+        <h2 class="section-title" data-i18n="features.title">Features</h2>
+        <p class="section-subtitle" data-i18n="features.subtitle">Everything you need to document your impact.</p>
+
+        <div class="features-grid">
+          <div class="feature-card">
+            <span class="feature-icon">🤖</span>
+            <h3 class="feature-title" data-i18n="feat1.title">AI Enrichment (STAR)</h3>
+            <p class="feature-desc" data-i18n="feat1.desc">Automatically converts raw entries into structured STAR narratives — Situation, Task, Action, Result — with tags and impact scores (1–5) via Anthropic or OpenAI.</p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon">🔄</span>
+            <h3 class="feature-title" data-i18n="feat2.title">GitHub / Jira / Linear Sync</h3>
+            <p class="feature-desc" data-i18n="feat2.desc">Pull merged PRs, closed issues, and completed tickets directly from your integrations. Deduplication ensures no entry appears twice.</p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon">🎯</span>
+            <h3 class="feature-title" data-i18n="feat3.title">OKR Tracking</h3>
+            <p class="feature-desc" data-i18n="feat3.desc">Associate accomplishments with your Objectives & Key Results. AI infers the best OKR match with high confidence so nothing falls through the cracks.</p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon">🚀</span>
+            <h3 class="feature-title" data-i18n="feat4.title">StarTrail — Career Path</h3>
+            <p class="feature-desc" data-i18n="feat4.desc">Load your career ladder document and set current/target roles so AI enrichment reflects the competencies that matter most for your next promotion.</p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon">📊</span>
+            <h3 class="feature-title" data-i18n="feat5.title">Performance Reports</h3>
+            <p class="feature-desc" data-i18n="feat5.desc">Generate AI-synthesized performance review narratives grouped by OKR and saved to your private GitHub repo — ready to paste into any review form.</p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon">📄</span>
+            <h3 class="feature-title" data-i18n="feat6.title">PDF &amp; Markdown Export</h3>
+            <p class="feature-desc" data-i18n="feat6.desc">Export reports as PDF (via headless Chrome) or Markdown to your local filesystem. Full fidelity, no vendor lock-in.</p>
+          </div>
+          <div class="feature-card">
+            <span class="feature-icon">🗄️</span>
+            <h3 class="feature-title" data-i18n="feat7.title">Private Storage</h3>
+            <p class="feature-desc" data-i18n="feat7.desc">Entries are saved locally by default (~/.brag/cache/). Connect a private GitHub repository at any time to sync your data to the cloud — no database required.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══ DEMO ══════════════════════════════════════════ -->
+    <section id="demo">
+      <div class="section-inner">
+        <h2 class="section-title" data-i18n="demo.title">Try it</h2>
+        <p class="section-subtitle" data-i18n="demo.subtitle">Add an accomplishment in seconds.</p>
+        <div class="demo-terminal">
+          <div class="terminal-bar">
+            <span class="terminal-dot red"></span>
+            <span class="terminal-dot yellow"></span>
+            <span class="terminal-dot green"></span>
+            <span class="terminal-title">Terminal</span>
+          </div>
+          <div class="terminal-body">
+            <pre><span class="t-prompt">$</span> <span class="t-answer">brag add "Refactored the payment service to reduce p99 latency by 40%"</span>
+
+<span class="t-success">✔</span> Entry saved locally <span class="t-muted">(~/.brag/cache/)</span>
+<span class="t-muted">  Run "brag enrich" to enrich with AI (STAR format)</span></pre>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══ HOW IT WORKS ══════════════════════════════════ -->
+    <section id="how-it-works">
+      <div class="section-inner">
+        <h2 class="section-title" data-i18n="how.title">How it works</h2>
+        <p class="section-subtitle" data-i18n="how.subtitle">Three commands to capture, enrich, and report your impact.</p>
+
+        <div class="steps">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3 class="step-title" data-i18n="step1.title">Configure</h3>
+            <p class="step-desc" data-i18n="step1.desc">Run the interactive setup wizard to connect your GitHub, Jira, Linear, and AI provider.</p>
+            <code class="step-code">brag init</code>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3 class="step-title" data-i18n="step2.title">Capture</h3>
+            <p class="step-desc" data-i18n="step2.desc">Add entries manually or let brag sync your recent work automatically from your integrations.</p>
+            <code class="step-code">brag sync &amp;&amp; brag enrich</code>
+          </div>
+          <div class="step">
+            <div class="step-number">3</div>
+            <h3 class="step-title" data-i18n="step3.title">Report</h3>
+            <p class="step-desc" data-i18n="step3.desc">Generate an AI-enriched performance report grouped by OKR and export it as PDF or Markdown.</p>
+            <code class="step-code">brag report &amp;&amp; brag export</code>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══ INSTALLATION ══════════════════════════════════ -->
+    <section id="installation">
+      <div class="section-inner">
+        <h2 class="section-title" data-i18n="install.title">Installation</h2>
+        <p class="section-subtitle" data-i18n="install.subtitle">Choose your preferred method.</p>
+
+        <div class="install-tabs-container">
+          <div class="tabs" role="tablist">
+            <button class="tab-btn active" data-tab="homebrew" role="tab" data-i18n="install.tab.homebrew">Homebrew</button>
+            <button class="tab-btn" data-tab="go" role="tab" data-i18n="install.tab.go">Go</button>
+            <button class="tab-btn" data-tab="download" role="tab" data-i18n="install.tab.download">Download</button>
+            <button class="tab-btn" data-tab="source" role="tab" data-i18n="install.tab.source">Source</button>
+          </div>
+
+          <div class="tab-panel active" data-panel="homebrew" role="tabpanel">
+            <div class="code-block">
+              <button class="code-copy-btn" aria-label="Copy code">Copy</button>
+              <pre><span class="comment"># Add the tap and install</span>
+<span class="cmd">brew install eduardohitek/tap/brag</span></pre>
+            </div>
+          </div>
+
+          <div class="tab-panel" data-panel="go" role="tabpanel">
+            <div class="code-block">
+              <button class="code-copy-btn" aria-label="Copy code">Copy</button>
+              <pre><span class="comment"># Requires Go 1.21+</span>
+<span class="cmd">go install github.com/eduardohitek/brag@latest</span></pre>
+            </div>
+          </div>
+
+          <div class="tab-panel" data-panel="download" role="tabpanel">
+            <div class="code-block">
+              <button class="code-copy-btn" aria-label="Copy code">Copy</button>
+              <pre><span class="comment"># Download binary for linux/darwin/windows (amd64 or arm64)</span>
+<span class="comment"># from https://github.com/eduardohitek/brag-cli/releases/latest</span>
+
+<span class="comment"># Example for macOS arm64:</span>
+<span class="cmd">curl -L https://github.com/eduardohitek/brag-cli/releases/latest/download/brag_Darwin_arm64.tar.gz | tar xz</span>
+<span class="cmd">mv brag /usr/local/bin/</span></pre>
+            </div>
+          </div>
+
+          <div class="tab-panel" data-panel="source" role="tabpanel">
+            <div class="code-block">
+              <button class="code-copy-btn" aria-label="Copy code">Copy</button>
+              <pre><span class="cmd">git clone https://github.com/eduardohitek/brag-cli</span>
+<span class="cmd">cd brag-cli</span>
+<span class="cmd">go build -o brag .</span>
+<span class="cmd">mv brag /usr/local/bin/</span></pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ══ ABOUT ══════════════════════════════════════════ -->
+    <section id="about">
+      <div class="section-inner">
+        <h2 class="section-title" data-i18n="about.title">About the Author</h2>
+
+        <div class="about-card">
+          <img
+            class="about-avatar"
+            src="https://avatars.githubusercontent.com/u/88193?v=4"
+            alt="Eduardo Hitek"
+            width="120"
+            height="120"
+            loading="lazy"
+          />
+          <div class="about-info">
+            <h3>Eduardo Hitek</h3>
+            <p class="about-role" data-i18n="about.role">Senior Software Engineer</p>
+            <p class="about-bio" data-i18n="about.bio">15+ years of experience in Backend, Fintech, distributed systems, payments, and PIX/BACEN domains. Currently at Stone. Passionate about developer tooling and craftsmanship.</p>
+            <div class="social-links">
+              <a class="social-link" href="https://github.com/eduardohitek" target="_blank" rel="noopener" aria-label="GitHub">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+                GitHub
+              </a>
+              <a class="social-link" href="https://twitter.com/eduardohitek" target="_blank" rel="noopener" aria-label="Twitter / X">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+                Twitter / X
+              </a>
+              <a class="social-link" href="https://linkedin.com/in/eduardohitek" target="_blank" rel="noopener" aria-label="LinkedIn">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                LinkedIn
+              </a>
+              <a class="social-link" href="http://eduardohitek.dev" target="_blank" rel="noopener" aria-label="Website">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                eduardohitek.dev
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ══ FOOTER ════════════════════════════════════════ -->
+  <footer>
+    <div class="footer-inner">
+      <p>
+        <span data-i18n="footer.built">Built with ❤️ by</span>
+        <a href="https://github.com/eduardohitek" target="_blank" rel="noopener"> Eduardo Hitek</a>
+      </p>
+      <div class="footer-links">
+        <a href="https://github.com/eduardohitek/brag-cli" target="_blank" rel="noopener" data-i18n="footer.repo">GitHub Repository</a>
+        <a href="https://github.com/eduardohitek/brag-cli/blob/main/LICENSE" target="_blank" rel="noopener" data-i18n="footer.license">MIT License</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,0 +1,235 @@
+const translations = {
+  en: {
+    "nav.logo": "$ brag",
+    "nav.theme.dark": "🌙",
+    "nav.theme.light": "☀️",
+    "nav.lang": "PT",
+
+    "hero.badge": "v0.8.0 — Open Source CLI",
+    "hero.h1.line1": "Track every win.",
+    "hero.h1.line2": "Own your career.",
+    "hero.subtitle": "A CLI tool for software engineers to log accomplishments, sync GitHub PRs, Jira tickets, and Linear issues, enrich them with AI using the STAR format, and generate structured performance review reports.",
+    "hero.cta.github": "View on GitHub",
+    "hero.install.label": "Quick install:",
+    "hero.install.copy": "Copy",
+    "hero.install.copied": "Copied!",
+
+    "features.title": "Features",
+    "features.subtitle": "Everything you need to document your impact.",
+    "feat1.title": "AI Enrichment (STAR)",
+    "feat1.desc": "Automatically converts raw entries into structured STAR narratives — Situation, Task, Action, Result — with tags and impact scores (1–5) via Anthropic or OpenAI.",
+    "feat2.title": "GitHub / Jira / Linear Sync",
+    "feat2.desc": "Pull merged PRs, closed issues, and completed tickets directly from your integrations. Deduplication ensures no entry appears twice.",
+    "feat3.title": "OKR Tracking",
+    "feat3.desc": "Associate accomplishments with your Objectives & Key Results. AI infers the best OKR match with high confidence so nothing falls through the cracks.",
+    "feat4.title": "StarTrail — Career Path",
+    "feat4.desc": "Load your career ladder document and set current/target roles so AI enrichment reflects the competencies that matter most for your next promotion.",
+    "feat5.title": "Performance Reports",
+    "feat5.desc": "Generate AI-synthesized performance review narratives grouped by OKR and saved to your private GitHub repo — ready to paste into any review form.",
+    "feat6.title": "PDF & Markdown Export",
+    "feat6.desc": "Export reports as PDF (via headless Chrome) or Markdown to your local filesystem. Full fidelity, no vendor lock-in.",
+    "feat7.title": "Private Storage",
+    "feat7.desc": "Entries are saved locally by default (~/.brag/cache/). Connect a private GitHub repository at any time to sync your data to the cloud — no database required.",
+
+    "demo.title": "Try it",
+    "demo.subtitle": "Add an accomplishment in seconds.",
+
+    "how.title": "How it works",
+    "how.subtitle": "Three commands to capture, enrich, and report your impact.",
+    "step1.title": "Configure",
+    "step1.desc": "Run the interactive setup wizard to connect your GitHub, Jira, Linear, and AI provider.",
+    "step2.title": "Capture",
+    "step2.desc": "Add entries manually or let brag sync your recent work automatically from your integrations.",
+    "step3.title": "Report",
+    "step3.desc": "Generate an AI-enriched performance report grouped by OKR and export it as PDF or Markdown.",
+
+    "install.title": "Installation",
+    "install.subtitle": "Choose your preferred method.",
+    "install.tab.homebrew": "Homebrew",
+    "install.tab.go": "Go",
+    "install.tab.download": "Download",
+    "install.tab.source": "Source",
+
+    "about.title": "About the Author",
+    "about.role": "Senior Software Engineer",
+    "about.bio": "15+ years of experience in Backend, Fintech, distributed systems, payments, and PIX/BACEN domains. Currently at Stone. Passionate about developer tooling and craftsmanship.",
+
+    "footer.built": "Built with ❤️ by",
+    "footer.license": "MIT License",
+    "footer.repo": "GitHub Repository",
+  },
+  pt: {
+    "nav.logo": "$ brag",
+    "nav.theme.dark": "🌙",
+    "nav.theme.light": "☀️",
+    "nav.lang": "EN",
+
+    "hero.badge": "v0.8.0 — CLI Open Source",
+    "hero.h1.line1": "Registre cada conquista.",
+    "hero.h1.line2": "Construa sua carreira.",
+    "hero.subtitle": "Uma ferramenta CLI para engenheiros de software registrarem conquistas, sincronizarem PRs do GitHub, tickets do Jira e issues do Linear, enriquecerem com IA (formato STAR) e gerarem relatórios estruturados de avaliação de desempenho.",
+    "hero.cta.github": "Ver no GitHub",
+    "hero.install.label": "Instalação rápida:",
+    "hero.install.copy": "Copiar",
+    "hero.install.copied": "Copiado!",
+
+    "features.title": "Funcionalidades",
+    "features.subtitle": "Tudo que você precisa para documentar seu impacto.",
+    "feat1.title": "Enriquecimento com IA (STAR)",
+    "feat1.desc": "Converte entradas brutas em narrativas STAR estruturadas — Situação, Tarefa, Ação, Resultado — com tags e pontuações de impacto (1–5) via Anthropic ou OpenAI.",
+    "feat2.title": "Sync GitHub / Jira / Linear",
+    "feat2.desc": "Importe PRs mesclados, issues fechadas e tickets concluídos diretamente das suas integrações. Deduplicação garante que nenhuma entrada apareça duas vezes.",
+    "feat3.title": "Acompanhamento de OKRs",
+    "feat3.desc": "Associe conquistas aos seus Objetivos e Resultados-Chave. A IA infere o melhor OKR com alta confiança para que nada se perca.",
+    "feat4.title": "StarTrail — Trilha de Carreira",
+    "feat4.desc": "Carregue o documento da sua trilha de carreira e defina os cargos atual e alvo para que o enriquecimento com IA reflita as competências mais relevantes para a sua próxima promoção.",
+    "feat5.title": "Relatórios de Desempenho",
+    "feat5.desc": "Gere narrativas de avaliação de desempenho agrupadas por OKR e salvas no seu repositório GitHub privado — prontas para colar em qualquer formulário de avaliação.",
+    "feat6.title": "Exportação PDF & Markdown",
+    "feat6.desc": "Exporte relatórios como PDF (via Chrome headless) ou Markdown para o seu sistema de arquivos local. Fidelidade total, sem lock-in de fornecedor.",
+    "feat7.title": "Armazenamento Privado",
+    "feat7.desc": "As entradas são salvas localmente por padrão (~/.brag/cache/). Conecte um repositório GitHub privado a qualquer momento para sincronizar seus dados na nuvem — sem banco de dados necessário.",
+
+    "demo.title": "Veja em ação",
+    "demo.subtitle": "Registre uma conquista em segundos.",
+
+    "how.title": "Como funciona",
+    "how.subtitle": "Três comandos para capturar, enriquecer e reportar seu impacto.",
+    "step1.title": "Configure",
+    "step1.desc": "Execute o assistente de configuração para conectar seu GitHub, Jira, Linear e provedor de IA.",
+    "step2.title": "Capture",
+    "step2.desc": "Adicione entradas manualmente ou deixe o brag sincronizar seu trabalho recente automaticamente das suas integrações.",
+    "step3.title": "Reporte",
+    "step3.desc": "Gere um relatório de desempenho enriquecido com IA agrupado por OKR e exporte como PDF ou Markdown.",
+
+    "install.title": "Instalação",
+    "install.subtitle": "Escolha o método de sua preferência.",
+    "install.tab.homebrew": "Homebrew",
+    "install.tab.go": "Go",
+    "install.tab.download": "Download",
+    "install.tab.source": "Código-fonte",
+
+    "about.title": "Sobre o Autor",
+    "about.role": "Engenheiro de Software Sênior",
+    "about.bio": "15+ anos de experiência em Backend, Fintech, sistemas distribuídos, pagamentos e domínios PIX/BACEN. Atualmente na Stone. Apaixonado por ferramentas para desenvolvedores e pelo artesanato de software.",
+
+    "footer.built": "Feito com ❤️ por",
+    "footer.license": "Licença MIT",
+    "footer.repo": "Repositório GitHub",
+  },
+};
+
+let currentLang = "en";
+let currentTheme = "dark";
+
+function applyLanguage(lang) {
+  currentLang = lang;
+  localStorage.setItem("brag_lang", lang);
+  const t = translations[lang];
+  document.querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    if (t[key] !== undefined) el.textContent = t[key];
+  });
+  // update lang toggle button label (shows the OTHER language)
+  const langBtn = document.getElementById("langToggle");
+  if (langBtn) langBtn.textContent = t["nav.lang"];
+  // update html lang attribute
+  document.documentElement.lang = lang === "pt" ? "pt-BR" : "en";
+}
+
+function applyTheme(theme) {
+  currentTheme = theme;
+  localStorage.setItem("brag_theme", theme);
+  document.documentElement.setAttribute("data-theme", theme);
+  const themeBtn = document.getElementById("themeToggle");
+  if (themeBtn) {
+    themeBtn.textContent = theme === "dark"
+      ? translations[currentLang]["nav.theme.dark"]
+      : translations[currentLang]["nav.theme.light"];
+    themeBtn.setAttribute("aria-label", theme === "dark" ? "Switch to light mode" : "Switch to dark mode");
+  }
+}
+
+function toggleTheme() {
+  applyTheme(currentTheme === "dark" ? "light" : "dark");
+}
+
+function toggleLang() {
+  applyLanguage(currentLang === "en" ? "pt" : "en");
+}
+
+function initTheme() {
+  const saved = localStorage.getItem("brag_theme");
+  if (saved) return saved;
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches) return "light";
+  return "dark";
+}
+
+function initLang() {
+  const saved = localStorage.getItem("brag_lang");
+  if (saved) return saved;
+  const nav = (navigator.language || "en").toLowerCase();
+  if (nav.startsWith("pt")) return "pt";
+  return "en";
+}
+
+// ─── Tabs ──────────────────────────────────────────────
+function initTabs() {
+  document.querySelectorAll(".tabs").forEach((tabGroup) => {
+    tabGroup.querySelectorAll(".tab-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const target = btn.getAttribute("data-tab");
+        const container = btn.closest(".install-tabs-container");
+        container.querySelectorAll(".tab-btn").forEach((b) => b.classList.remove("active"));
+        container.querySelectorAll(".tab-panel").forEach((p) => p.classList.remove("active"));
+        btn.classList.add("active");
+        container.querySelector(`[data-panel="${target}"]`).classList.add("active");
+      });
+    });
+  });
+}
+
+// ─── Copy buttons ──────────────────────────────────────
+function initCopyButtons() {
+  document.querySelectorAll("[data-copy]").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const text = btn.getAttribute("data-copy");
+      navigator.clipboard.writeText(text).then(() => {
+        const original = btn.textContent;
+        btn.textContent = translations[currentLang]["hero.install.copied"] || "Copied!";
+        btn.classList.add("copied");
+        setTimeout(() => {
+          btn.textContent = original;
+          btn.classList.remove("copied");
+        }, 2000);
+      });
+    });
+  });
+
+  document.querySelectorAll(".code-copy-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const block = btn.closest(".code-block");
+      const text = block.querySelector("pre").innerText;
+      navigator.clipboard.writeText(text).then(() => {
+        const original = btn.textContent;
+        btn.textContent = "✓ Copied";
+        btn.classList.add("copied");
+        setTimeout(() => {
+          btn.textContent = original;
+          btn.classList.remove("copied");
+        }, 2000);
+      });
+    });
+  });
+}
+
+// ─── Init ──────────────────────────────────────────────
+document.addEventListener("DOMContentLoaded", () => {
+  applyTheme(initTheme());
+  applyLanguage(initLang());
+  initTabs();
+  initCopyButtons();
+
+  document.getElementById("themeToggle").addEventListener("click", toggleTheme);
+  document.getElementById("langToggle").addEventListener("click", toggleLang);
+});


### PR DESCRIPTION
## Summary

- Adds a static HTML/CSS/JS landing page in `/docs`, served via GitHub Pages
- Dark/light theme toggle with auto-detect from `prefers-color-scheme`, fallback to dark, persisted in `localStorage`
- EN/PT language toggle with auto-detect from `navigator.language`, persisted in `localStorage`
- 7 feature cards including new **Private Storage** card (local-first by default)
- **"Try it"** section with a simulated terminal showing `brag add "..."` in action
- Installation section with 4 tabs (Homebrew, Go, Download, Source)
- Author profile with GitHub, Twitter/X, LinkedIn, and personal website links
- GitHub Actions workflow (`.github/workflows/pages.yml`) for automatic deploy on push to `main`

## Activation

After merging, enable GitHub Pages in the repository settings:
`Settings → Pages → Source: GitHub Actions`

## Test plan

- [ ] Open `docs/index.html` locally and verify dark/light toggle works
- [ ] Toggle EN ↔ PT and confirm all text changes language
- [ ] Reload page and verify theme and language preferences are remembered
- [ ] Check responsiveness on mobile (≤ 375px) and desktop (≥ 1280px)
- [ ] After merge: confirm GitHub Actions deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)