### PR TITLE
feat: add local SHA-based cache for brag list

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,13 @@ brag list --source github
 brag list --okr OKR-2025-Q1-01
 brag list --no-okr
 brag list --from 2025-01-01 --to 2025-03-31
+brag list --refresh                      # força busca completa no GitHub
 ```
+
+O `brag list` mantém um cache local em `~/.brag/cache/` para evitar múltiplas chamadas ao GitHub a cada execução. Na primeira listagem, os dados são baixados do GitHub e armazenados localmente. Nas execuções seguintes, apenas 1 chamada de rede é feita para verificar se houve mudanças (via SHA dos arquivos); os arquivos inalterados são lidos do disco.
+
+- **`--refresh`**: ignora o cache e força o download completo do GitHub.
+- **Offline**: se o GitHub estiver inacessível e o cache existir, as entradas são exibidas com um aviso.
 
 ### Enriquecer entradas com IA
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -65,7 +65,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	// Push to GitHub repo
 	if cfg.Storage.GithubToken != "" && cfg.Storage.Repo != "" {
-		s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+		s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 		if err != nil {
 			return fmt.Errorf("creating store: %w", err)
 		}

--- a/cmd/enrich.go
+++ b/cmd/enrich.go
@@ -49,7 +49,7 @@ func runEnrich(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("storage not configured — run `brag init`")
 	}
 
-	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -44,7 +44,7 @@ func runExport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("storage not configured — run `brag init`")
 	}
 
-	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,6 +23,7 @@ var (
 	listOKR     string
 	listProject string
 	listNoOKR   bool
+	listRefresh bool
 )
 
 var listCmd = &cobra.Command{
@@ -41,6 +42,7 @@ func init() {
 	listCmd.Flags().StringVar(&listOKR, "okr", "", "Filter by OKR ID")
 	listCmd.Flags().StringVar(&listProject, "project", "", "Filter by GitHub project name")
 	listCmd.Flags().BoolVar(&listNoOKR, "no-okr", false, "Show only entries without an OKR")
+	listCmd.Flags().BoolVar(&listRefresh, "refresh", false, "Force refresh from GitHub, ignoring local cache")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -55,17 +57,18 @@ func runList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("storage not configured — run `brag init`")
 	}
 
-	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}
 
 	opts := store.ListOptions{
-		Tag:     listTag,
-		Source:  listSource,
-		OKR:     listOKR,
-		Project: listProject,
-		NoOKR:   listNoOKR,
+		Tag:          listTag,
+		Source:       listSource,
+		OKR:          listOKR,
+		Project:      listProject,
+		NoOKR:        listNoOKR,
+		ForceRefresh: listRefresh,
 	}
 
 	if listPeriod != "" {

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -50,7 +50,7 @@ func runReport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("storage not configured — run `brag init`")
 	}
 
-	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -46,7 +46,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("storage GitHub token and repo must be configured (run `brag init`)")
 	}
 
-	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}

--- a/cmd/sync_cache.go
+++ b/cmd/sync_cache.go
@@ -33,7 +33,7 @@ func runSyncCache(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("GitHub storage not configured — run `brag init`")
 	}
 
-	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo)
+	s, err := store.New(cfg.Storage.GithubToken, cfg.Storage.Repo, config.CacheDir())
 	if err != nil {
 		return fmt.Errorf("creating store: %w", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -13,12 +14,13 @@ import (
 )
 
 type Store struct {
-	client *github.Client
-	owner  string
-	repo   string
+	client   *github.Client
+	owner    string
+	repo     string
+	cacheDir string
 }
 
-func New(token, ownerRepo string) (*Store, error) {
+func New(token, ownerRepo, cacheDir string) (*Store, error) {
 	parts := strings.SplitN(ownerRepo, "/", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid repo format %q, expected owner/repo", ownerRepo)
@@ -26,9 +28,10 @@ func New(token, ownerRepo string) (*Store, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.Background(), ts)
 	return &Store{
-		client: github.NewClient(tc),
-		owner:  parts[0],
-		repo:   parts[1],
+		client:   github.NewClient(tc),
+		owner:    parts[0],
+		repo:     parts[1],
+		cacheDir: cacheDir,
 	}, nil
 }
 
@@ -49,9 +52,12 @@ func (s *Store) SaveEntry(ctx context.Context, e *Entry) error {
 		Message: &msg,
 		Content: []byte(encoded),
 	}
-	_, _, err = s.client.Repositories.CreateFile(ctx, s.owner, s.repo, path, opts)
+	resp, _, err := s.client.Repositories.CreateFile(ctx, s.owner, s.repo, path, opts)
 	if err != nil {
 		return fmt.Errorf("creating file in repo: %w", err)
+	}
+	if s.cacheDir != "" && resp.Content != nil {
+		_ = s.writeEntryToCache(e, path, resp.Content.GetSHA())
 	}
 	return nil
 }
@@ -72,27 +78,37 @@ func (s *Store) UpdateEntry(ctx context.Context, e *Entry) error {
 		Content: []byte(encoded),
 		SHA:     &e.FileSHA,
 	}
-	_, _, err = s.client.Repositories.UpdateFile(ctx, s.owner, s.repo, path, opts)
+	resp, _, err := s.client.Repositories.UpdateFile(ctx, s.owner, s.repo, path, opts)
 	if err != nil {
 		return fmt.Errorf("updating file in repo: %w", err)
+	}
+	if s.cacheDir != "" && resp.Content != nil {
+		_ = s.writeEntryToCache(e, path, resp.Content.GetSHA())
 	}
 	return nil
 }
 
 type ListOptions struct {
-	Since   *time.Time
-	From    *time.Time
-	To      *time.Time
-	Tag     string
-	Source  string
-	OKR     string
-	Project string
-	NoOKR   bool
+	Since        *time.Time
+	From         *time.Time
+	To           *time.Time
+	Tag          string
+	Source       string
+	OKR          string
+	Project      string
+	NoOKR        bool
+	ForceRefresh bool
 }
 
 func (s *Store) ListEntries(ctx context.Context, opts ListOptions) ([]*Entry, error) {
+	meta := s.loadCacheMeta()
+
 	_, dirContents, _, err := s.client.Repositories.GetContents(ctx, s.owner, s.repo, "entries", nil)
 	if err != nil {
+		if s.cacheDir != "" && len(meta.Entries) > 0 {
+			fmt.Fprintln(os.Stderr, "[aviso: sem acesso ao GitHub — exibindo cache local]")
+			return s.listEntriesFromCache(meta, opts)
+		}
 		return nil, fmt.Errorf("listing entries directory: %w", err)
 	}
 
@@ -101,53 +117,45 @@ func (s *Store) ListEntries(ctx context.Context, opts ListOptions) ([]*Entry, er
 		if fc.GetType() != "file" || !strings.HasSuffix(fc.GetName(), ".json") {
 			continue
 		}
-		fileContent, _, _, err := s.client.Repositories.GetContents(ctx, s.owner, s.repo, fc.GetPath(), nil)
-		if err != nil {
-			continue
+
+		var e *Entry
+		cached, inCache := meta.Entries[fc.GetPath()]
+		if !opts.ForceRefresh && inCache && cached.SHA == fc.GetSHA() && s.cacheDir != "" {
+			e, err = s.readEntryFromCache(fc.GetName(), cached.SHA)
+			if err != nil {
+				e = nil // fallthrough to GitHub fetch on read error
+			}
 		}
-		rawContent, _ := fileContent.GetContent()
-		decoded, err := base64.StdEncoding.DecodeString(rawContent)
-		if err != nil {
-			// GitHub sometimes returns content with newlines; strip them
-			cleaned := strings.ReplaceAll(rawContent, "\n", "")
-			decoded, err = base64.StdEncoding.DecodeString(cleaned)
+
+		if e == nil {
+			fileContent, _, _, err := s.client.Repositories.GetContents(ctx, s.owner, s.repo, fc.GetPath(), nil)
 			if err != nil {
 				continue
 			}
-		}
-		var e Entry
-		if err := json.Unmarshal(decoded, &e); err != nil {
-			continue
-		}
-		e.FileSHA = fileContent.GetSHA()
-
-		// Apply filters
-		if opts.Since != nil && e.Date.Before(*opts.Since) {
-			continue
-		}
-		if opts.From != nil && e.Date.Before(*opts.From) {
-			continue
-		}
-		if opts.To != nil && e.Date.After(*opts.To) {
-			continue
-		}
-		if opts.Source != "" && e.Source != opts.Source {
-			continue
-		}
-		if opts.OKR != "" && (e.OKR == nil || e.OKR.ID != opts.OKR) {
-			continue
-		}
-		if opts.NoOKR && e.OKR != nil {
-			continue
-		}
-		if opts.Project != "" && e.GithubProject != opts.Project {
-			continue
-		}
-		if opts.Tag != "" && !containsTag(e.Tags, opts.Tag) {
-			continue
+			rawContent, _ := fileContent.GetContent()
+			decoded, err := base64.StdEncoding.DecodeString(rawContent)
+			if err != nil {
+				cleaned := strings.ReplaceAll(rawContent, "\n", "")
+				decoded, err = base64.StdEncoding.DecodeString(cleaned)
+				if err != nil {
+					continue
+				}
+			}
+			var entry Entry
+			if err := json.Unmarshal(decoded, &entry); err != nil {
+				continue
+			}
+			entry.FileSHA = fileContent.GetSHA()
+			e = &entry
+			if s.cacheDir != "" {
+				_ = s.writeEntryToCache(e, fc.GetPath(), fileContent.GetSHA())
+			}
 		}
 
-		entries = append(entries, &e)
+		if !applyFilters(e, opts) {
+			continue
+		}
+		entries = append(entries, e)
 	}
 	return entries, nil
 }

--- a/internal/store/store_cache.go
+++ b/internal/store/store_cache.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type fileMeta struct {
+	SHA     string `json:"sha"`
+	EntryID string `json:"entry_id"`
+}
+
+type cacheMeta struct {
+	Entries map[string]fileMeta `json:"entries"`
+}
+
+func (s *Store) metaPath() string {
+	return filepath.Join(s.cacheDir, ".meta.json")
+}
+
+func (s *Store) loadCacheMeta() *cacheMeta {
+	m := &cacheMeta{Entries: make(map[string]fileMeta)}
+	if s.cacheDir == "" {
+		return m
+	}
+	data, err := os.ReadFile(s.metaPath())
+	if err != nil {
+		return m
+	}
+	_ = json.Unmarshal(data, m)
+	if m.Entries == nil {
+		m.Entries = make(map[string]fileMeta)
+	}
+	return m
+}
+
+func (s *Store) saveCacheMeta(m *cacheMeta) error {
+	if err := os.MkdirAll(s.cacheDir, 0700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.metaPath(), data, 0600)
+}
+
+func (s *Store) writeEntryToCache(e *Entry, githubPath, sha string) error {
+	if err := os.MkdirAll(s.cacheDir, 0700); err != nil {
+		return err
+	}
+	filename := filepath.Base(githubPath)
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(s.cacheDir, filename), data, 0600); err != nil {
+		return err
+	}
+	m := s.loadCacheMeta()
+	m.Entries[githubPath] = fileMeta{SHA: sha, EntryID: e.ID}
+	return s.saveCacheMeta(m)
+}
+
+func (s *Store) readEntryFromCache(filename, sha string) (*Entry, error) {
+	data, err := os.ReadFile(filepath.Join(s.cacheDir, filename))
+	if err != nil {
+		return nil, err
+	}
+	var e Entry
+	if err := json.Unmarshal(data, &e); err != nil {
+		return nil, err
+	}
+	e.FileSHA = sha
+	return &e, nil
+}
+
+func (s *Store) listEntriesFromCache(m *cacheMeta, opts ListOptions) ([]*Entry, error) {
+	var entries []*Entry
+	for githubPath, fm := range m.Entries {
+		filename := filepath.Base(githubPath)
+		if !strings.HasSuffix(filename, ".json") {
+			continue
+		}
+		e, err := s.readEntryFromCache(filename, fm.SHA)
+		if err != nil {
+			continue
+		}
+		if !applyFilters(e, opts) {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+func applyFilters(e *Entry, opts ListOptions) bool {
+	if opts.Since != nil && e.Date.Before(*opts.Since) {
+		return false
+	}
+	if opts.From != nil && e.Date.Before(*opts.From) {
+		return false
+	}
+	if opts.To != nil && e.Date.After(*opts.To) {
+		return false
+	}
+	if opts.Source != "" && e.Source != opts.Source {
+		return false
+	}
+	if opts.OKR != "" && (e.OKR == nil || e.OKR.ID != opts.OKR) {
+		return false
+	}
+	if opts.NoOKR && e.OKR != nil {
+		return false
+	}
+	if opts.Project != "" && e.GithubProject != opts.Project {
+		return false
+	}
+	if opts.Tag != "" && !containsTag(e.Tags, opts.Tag) {
+		return false
+	}
+	return true
+}
+


### PR DESCRIPTION
## Summary

- Adiciona cache local em `~/.brag/cache/` com detecção de desatualização via SHA de arquivo do GitHub
- `brag list` agora faz **1 chamada de rede** (em vez de N+1) na maioria dos casos — apenas verifica o diretório e baixa arquivos com SHA diferente
- Adiciona flag `--refresh` para forçar busca completa no GitHub
- Modo offline: se o GitHub estiver inacessível e o cache existir, exibe entradas com aviso
- Write-through: `SaveEntry` e `UpdateEntry` atualizam o cache automaticamente após cada escrita

## Detalhes técnicos

- Novo arquivo `internal/store/store_cache.go` com tipos `fileMeta`/`cacheMeta` e helpers de leitura/escrita
- `Store.New()` recebe `cacheDir string` como terceiro argumento (todos os callers atualizados)
- `ListOptions` ganha campo `ForceRefresh bool`
- Metadata do cache em `~/.brag/cache/.meta.json` (mapeia path GitHub → SHA + entry ID)
- `FileSHA` injetado a partir do metadata ao ler do cache, mantendo `brag enrich` funcional

## Test plan

- [ ] `brag list` — primeira execução: popula cache, comportamento igual ao anterior
- [ ] `brag list` — segunda execução: notavelmente mais rápido (1 chamada de rede)
- [ ] `brag list --refresh` — força busca completa no GitHub
- [ ] Desligar rede e rodar `brag list` — exibe entradas com aviso de cache local
- [ ] `brag add "teste"` — `.meta.json` atualizado com SHA da nova entrada
- [ ] `brag enrich` — entry no cache atualizada com campo `enriched`
- [ ] `go build ./...` e `go vet ./...` sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)